### PR TITLE
fix: adicionando caracteres com acento na validação de nome do cadastro

### DIFF
--- a/src/masks/userName.mask.ts
+++ b/src/masks/userName.mask.ts
@@ -1,5 +1,5 @@
 const userNameMask = (name: string): string => {
-  return name.replace(/[^a-zA-Z ]/g, '');
+  return name.replace(/[^a-z A-Z à-ù À-Ù]/g, '');
 };
 
 export default userNameMask;

--- a/src/masks/userName.mask.ts
+++ b/src/masks/userName.mask.ts
@@ -1,5 +1,5 @@
 const userNameMask = (name: string): string => {
-  return name.replace(/[^a-z A-Z à-ù À-Ù]/g, '');
+  return name.replace(/[^a-zA-Zà-ùÀ-Ù ]/g, '');
 };
 
 export default userNameMask;


### PR DESCRIPTION
Hoje, ao digitar caracteres com acentos ao cadastrar seu nome, eles não entram no input
![Captura de tela de 2023-03-07 20-50-44](https://user-images.githubusercontent.com/24192460/223582080-c02c5215-dea8-44c9-aa8b-5e54c8c038ec.png)

Adicionei o range de caracteres com acento no regex de nome para que eles sejam aceitos
![Captura de tela de 2023-03-07 20-40-25](https://user-images.githubusercontent.com/24192460/223582087-fc4ee37b-a071-401d-b3a7-5b1320c2c5ef.png)
